### PR TITLE
Improve tmux mouse selection behavior

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -34,6 +34,9 @@ bind -n -r M-S-Right resize-pane -R 2
 
 # enable mouse control
 set-option -g mouse on
+# keep copy-mode active after mouse selections
+unbind -T copy-mode-vi MouseDragEnd1Pane
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection
 
 # don't rename windows automatically
 set-option -g allow-rename off
@@ -59,7 +62,7 @@ set-option -g status-left '[#S]'
 set-option -g status-left-style 'fg=green bg=black'
 set-option -g status-left-length 10
 set-option -g status-right-style 'fg=black bg=yellow'
-set-option -g status-right '%Y-%m-%d %H:%M '
+set-option -g status-right ''
 set-option -g status-right-length 50
 set-window-option -g window-status-current-style 'fg=black bg=green'
 set-window-option -g window-status-current-format ' #I #W #F '


### PR DESCRIPTION
## Summary
- keep copy-mode active after mouse selections by overriding the default mouse drag binding
- remove the timestamp from the status-right display

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187e83a8a08328807d48d499ba5f58)