### PR TITLE
Configure i3 startup applications per workspace

### DIFF
--- a/dot_config/i3/config
+++ b/dot_config/i3/config
@@ -25,6 +25,13 @@ exec --no-startup-id dex --autostart --environment i3
 exec --no-startup-id feh --bg-scale /home/sota/pictures/neko.jpg
 exec_always --no-startup-id /home/sota/.config/i3/polybar.sh &
 
+# Launch startup applications on dedicated workspaces
+exec --no-startup-id i3-msg 'workspace number $ws1; exec --no-startup-id alacritty'
+exec --no-startup-id i3-msg 'workspace number $ws2; exec --no-startup-id discord'
+exec --no-startup-id i3-msg 'workspace number $ws2; exec --no-startup-id slack'
+exec --no-startup-id i3-msg 'workspace number $ws3; exec --no-startup-id zen'
+exec --no-startup-id i3-msg 'workspace number $ws1'
+
 # The combination of xss-lock, nm-applet and pactl is a popular choice, so
 # they are included here as an example. Modify as you see fit.
 


### PR DESCRIPTION
## Summary
- launch Alacritty on workspace 1 during i3 startup
- start Discord and Slack on workspace 2 automatically
- open Zen browser on workspace 3 and return focus to workspace 1 after startup commands

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aa79c4ae08328a0fc28f44bb124df)